### PR TITLE
Fixed impurity naming function to include boron

### DIFF
--- a/src/openadas.cpp
+++ b/src/openadas.cpp
@@ -65,6 +65,7 @@ namespace OpenADAS
 		else if (imp_atom_num == 42) imp_name = "mo";
 		else if (imp_atom_num == 74) imp_name = "w";
 		
+
 		else
 		{
 			std::cerr << "Error! imp_atom_num = " << imp_atom_num << " is not"

--- a/src/openadas.cpp
+++ b/src/openadas.cpp
@@ -59,10 +59,10 @@ namespace OpenADAS
 		// Select element name from atomic number.
 		std::string imp_name {};
 		if (imp_atom_num == 5) imp_name = "b";
-		else if (imp_atom_num == 6) imp_name = 'c';
-		else if (imp_atom_num == 14) imp_name = 'si';
-		else if (imp_atom_num == 26) imp_name = 'fe';
-		else if (imp_atom_num == 42) imp_name = 'mo';
+		else if (imp_atom_num == 6) imp_name = "c";
+		else if (imp_atom_num == 14) imp_name = "si";
+		else if (imp_atom_num == 26) imp_name = "fe";
+		else if (imp_atom_num == 42) imp_name = "mo";
 		else if (imp_atom_num == 74) imp_name = "w";
 		
 		else


### PR DESCRIPTION
Within src/openadas.cpp, I added iron, molybdenum, silicon, and boron capabilities to the imp_name function.